### PR TITLE
Enable detecting paths from shims

### DIFF
--- a/evm.el
+++ b/evm.el
@@ -42,10 +42,13 @@
 
 (defun evm--installation-path ()
   "Path to currently selected package."
-  (let ((path (f-canonical (f-join evm-path "bin" "evm-emacs"))))
-    (if (f-exists? path)
-        (car (s-match (f-join evm-local-path "\\([^/]+\\)") path))
-      (error "No currently selected Emacs"))))
+  (let ((evm-emacs-path (f-join evm-path "bin" "evm-emacs")))
+    (let ((path (if (f-symlink? evm-emacs-path)
+                    (f-canonical evm-emacs-path)
+                  (s-chomp (shell-command-to-string "evm bin")))))
+      (if (f-exists? path)
+          (car (s-match (f-join evm-local-path "\\([^/]+\\)") path))
+        (error "No currently selected Emacs")))))
 
 (defun evm--osx? ()
   "Return true if OSX, false otherwise."


### PR DESCRIPTION
Since https://github.com/rejeep/evm/commit/29b83c433c80f37b32a7cb7ddb99f2908ab4cfd5, it isn't possible to find out the selected Emacs version by resolving the `evm-emacs` symlink, as it has been replaced by a shim. 

This PR suggests that if `evm-emacs` isn't a link, use the `evm bin` command to find out the path to the currently selected package instead.

I have no idea if this is a sensible solution, nor how to properly format elisp. I mainly wanted to highlight the issue, and didn't want to do so empty handedly.